### PR TITLE
Add simple Web client skeleton

### DIFF
--- a/WebClient/app.js
+++ b/WebClient/app.js
@@ -1,0 +1,32 @@
+let map;
+let socket;
+
+function initMap() {
+  map = L.map('map').setView([0, 0], 2);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+}
+
+function connect() {
+  // Placeholder websocket connection. The protocol is unknown but we connect anyway.
+  socket = new WebSocket('ws://localhost:30069');
+  socket.onopen = () => console.log('connected');
+  socket.onmessage = evt => console.log('message', evt.data);
+  socket.onerror = err => console.error('socket error', err);
+  socket.onclose = () => console.log('connection closed');
+}
+
+document.getElementById('connect').addEventListener('click', connect);
+document.getElementById('fire').addEventListener('click', () => {
+  if(socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({action: 'fire'}));
+  }
+});
+document.getElementById('intercept').addEventListener('click', () => {
+  if(socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({action: 'intercept'}));
+  }
+});
+
+initMap();

--- a/WebClient/index.html
+++ b/WebClient/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Launch Web Client</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+4J2O7SIPr+VFQ1S4vTSVXvkh6cOR8KJO+3Lrw1j0=" crossorigin=""/>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="map"></div>
+  <div id="controls">
+    <button id="connect">Connect</button>
+    <button id="fire">Fire Missile</button>
+    <button id="intercept">Intercept</button>
+  </div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j+rVvycP1UxzEfofviGEmZr3Eld4FpqM2MDYy+o=" crossorigin=""></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/WebClient/style.css
+++ b/WebClient/style.css
@@ -1,0 +1,16 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+#map {
+  height: 80vh;
+}
+#controls {
+  padding: 10px;
+  text-align: center;
+}
+button {
+  margin: 0 5px;
+  padding: 10px 20px;
+}


### PR DESCRIPTION
## Summary
- add `WebClient` skeleton using Leaflet instead of Google Maps
- include buttons and placeholder WebSocket calls

## Testing
- `./LaunchClient/gradlew test --quiet` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_6840044b1b388321984438574266ca31