### PR TITLE
Update README for Bun server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,46 @@
 Real world RTS for Android
 
 Aspirations are to randomize player locations each week and use mars instead of earth for the map. Players actual GPS stays hidden and only an offset is applied to in game locations
+
+## Running the Bun Server
+
+The latest server implementation uses [Bun](https://bun.sh/) to provide a fast
+TypeScript runtime. To start the server in development mode run:
+
+```bash
+bun run server.ts
+```
+
+By default the server listens on port `3000`. You can override this with the
+`PORT` environment variable:
+
+```bash
+PORT=8080 bun run server.ts
+```
+
+When deploying you may wish to build the project first. Bun can produce a
+single JavaScript bundle which can then be executed directly:
+
+```bash
+bun build server.ts --outfile dist/server.js
+node dist/server.js
+```
+
+## Protocol Changes
+
+Older versions of Launch relied on a custom binary protocol implemented in the
+`TobComm` library. Messages were transmitted as byte arrays with manually coded
+offsets for each field. The new implementation uses JSON over WebSockets. This
+makes it much easier to inspect traffic and build tooling in other languages,
+while still keeping the payloads small thanks to Bun's native JSON handling.
+
+## Running Tests
+
+Tests for the Bun services can be executed with:
+
+```bash
+bun test
+```
+
+Existing Java modules still contain JUnit tests under `LaunchGame/test` which
+can be run with your preferred Java IDE or with Ant/NetBeans.


### PR DESCRIPTION
## Summary
- document how to run the Bun-based server
- describe the move from binary protocol to JSON
- mention port configuration, building with Bun and how to run tests

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683ff53f30248321b0f2b9ccfcfbf2b7