### PR TITLE
Add bun tests and configure package.json

### DIFF
--- a/js/src/entities.ts
+++ b/js/src/entities.ts
@@ -1,0 +1,32 @@
+export class Damagable {
+  hp: number;
+  maxHp: number;
+  constructor(maxHp: number) {
+    this.hp = maxHp;
+    this.maxHp = maxHp;
+  }
+
+  inflictDamage(amount: number): number {
+    const actual = Math.min(this.hp, amount);
+    this.hp -= amount;
+    if (this.hp < 0) this.hp = 0;
+    return actual;
+  }
+
+  addHP(amount: number) {
+    this.hp += amount;
+    if (this.hp > this.maxHp) this.hp = this.maxHp;
+  }
+
+  destroyed(): boolean {
+    return this.hp <= 0;
+  }
+}
+
+export class Player extends Damagable {
+  name: string;
+  constructor(name: string, maxHp: number) {
+    super(maxHp);
+    this.name = name;
+  }
+}

--- a/js/src/protocol.ts
+++ b/js/src/protocol.ts
@@ -1,0 +1,34 @@
+export function serializeString(str: string): Uint8Array {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(str);
+  const buffer = new Uint8Array(2 + bytes.length);
+  const view = new DataView(buffer.buffer);
+  view.setUint16(0, bytes.length, false);
+  buffer.set(bytes, 2);
+  return buffer;
+}
+
+export function deserializeString(buffer: Uint8Array): string {
+  const view = new DataView(buffer.buffer);
+  const len = view.getUint16(0, false);
+  const bytes = buffer.slice(2, 2 + len);
+  return new TextDecoder().decode(bytes);
+}
+
+export function serializeIntList(list: number[]): Uint8Array {
+  const buffer = new Uint8Array(2 + list.length * 4);
+  const view = new DataView(buffer.buffer);
+  view.setUint16(0, list.length, false);
+  list.forEach((v, i) => view.setInt32(2 + i * 4, v, false));
+  return buffer;
+}
+
+export function deserializeIntList(buffer: Uint8Array): number[] {
+  const view = new DataView(buffer.buffer);
+  const len = view.getUint16(0, false);
+  const out: number[] = [];
+  for (let i = 0; i < len; i++) {
+    out.push(view.getInt32(2 + i * 4, false));
+  }
+  return out;
+}

--- a/js/test/entities.test.ts
+++ b/js/test/entities.test.ts
@@ -1,0 +1,20 @@
+import { Player } from '../src/entities';
+import { describe, expect, test } from 'bun:test';
+
+describe('player entity', () => {
+  test('creation sets name and hp', () => {
+    const p = new Player('Bob', 100);
+    expect(p.name).toBe('Bob');
+    expect(p.hp).toBe(100);
+  });
+
+  test('health regeneration', () => {
+    const p = new Player('Alice', 50);
+    p.inflictDamage(20);
+    expect(p.hp).toBe(30);
+    p.addHP(10);
+    expect(p.hp).toBe(40);
+    p.addHP(20); // should cap at max
+    expect(p.hp).toBe(50);
+  });
+});

--- a/js/test/protocol.test.ts
+++ b/js/test/protocol.test.ts
@@ -1,0 +1,15 @@
+import { serializeString, deserializeString, serializeIntList, deserializeIntList } from '../src/protocol';
+import { describe, expect, test } from 'bun:test';
+
+describe('protocol serialization', () => {
+  test('string roundtrip', () => {
+    const buf = serializeString('hello');
+    expect(deserializeString(buf)).toBe('hello');
+  });
+
+  test('int list roundtrip', () => {
+    const list = [1, 2, 3, 999];
+    const buf = serializeIntList(list);
+    expect(deserializeIntList(buf)).toEqual(list);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "launch",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["js/src/**/*", "js/test/**/*"]
+}


### PR DESCRIPTION
## Summary
- set up bun as the test runner via `package.json`
- implement small protocol helpers and entity classes in TypeScript
- write bun tests for protocol (string/int list round-trips)
- add unit tests for player creation and health regeneration

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683ff53e29c483218f3f57b1aa59a968