### PR TITLE
Add LaunchServerJS logging utility

### DIFF
--- a/LaunchServerJS/package.json
+++ b/LaunchServerJS/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "launchserverjs",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "@types/node": "^20.5.9"
+  }
+}

--- a/LaunchServerJS/src/server.ts
+++ b/LaunchServerJS/src/server.ts
@@ -1,0 +1,15 @@
+import { Logger } from './utils/log';
+
+process.on('uncaughtException', (err: unknown) => {
+  Logger.error(`Unhandled exception: ${err instanceof Error ? err.stack : err}`);
+});
+
+process.on('unhandledRejection', (reason: unknown) => {
+  Logger.error(`Unhandled rejection: ${reason}`);
+});
+
+Logger.info('LaunchServer starting');
+
+setInterval(() => {
+  Logger.info('Server heartbeat');
+}, 60000);

--- a/LaunchServerJS/src/utils/log.ts
+++ b/LaunchServerJS/src/utils/log.ts
@@ -1,0 +1,24 @@
+export enum LogLevel {
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR'
+}
+
+export class Logger {
+  private static format(level: LogLevel, message: string): string {
+    const timestamp = new Date().toISOString();
+    return `${timestamp} - ${level}: ${message}`;
+  }
+
+  static info(message: string): void {
+    console.log(Logger.format(LogLevel.INFO, message));
+  }
+
+  static warn(message: string): void {
+    console.warn(Logger.format(LogLevel.WARN, message));
+  }
+
+  static error(message: string): void {
+    console.error(Logger.format(LogLevel.ERROR, message));
+  }
+}

--- a/LaunchServerJS/tsconfig.json
+++ b/LaunchServerJS/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- add basic TypeScript server and logger
- log unhandled exceptions

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_683ff53dc8b083219354ea713f8d3144