### PR TITLE
Add simple WebSocket bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 Real world RTS for Android
 
 Aspirations are to randomize player locations each week and use mars instead of earth for the map. Players actual GPS stays hidden and only an offset is applied to in game locations
+
+## WebSocket Bridge
+
+A simple Node.js server under `wsbridge/` exposes game actions over WebSockets and
+broadcasts JSON updates whenever in-game entities change. Run it with:
+
+```bash
+cd wsbridge
+node server.js
+```
+
+Incoming messages should be JSON objects with a `type` field and optional
+`payload`. Legacy message names such as `MOVE` or `FIRE` are automatically mapped
+to the new action names.

--- a/wsbridge/package-lock.json
+++ b/wsbridge/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "wsbridge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wsbridge",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/wsbridge/package.json
+++ b/wsbridge/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "wsbridge",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "ws": "^8.18.2"
+  }
+}

--- a/wsbridge/server.js
+++ b/wsbridge/server.js
@@ -1,0 +1,77 @@
+const WebSocket = require('ws');
+const EventEmitter = require('events');
+
+class Game extends EventEmitter {
+  constructor() {
+    super();
+  }
+
+  // Example action handlers.
+  movePlayer(playerId, x, y) {
+    this.emit('entityChange', { type: 'move', id: playerId, x, y });
+  }
+
+  fireMissile(playerId, targetId) {
+    this.emit('entityChange', { type: 'missile', id: playerId, targetId });
+  }
+
+  handleAction(action) {
+    const { type, payload } = action;
+    switch (type) {
+      case 'move':
+        if (payload && typeof payload.playerId === 'number' &&
+            typeof payload.x === 'number' && typeof payload.y === 'number') {
+          this.movePlayer(payload.playerId, payload.x, payload.y);
+        }
+        break;
+      case 'fireMissile':
+        if (payload && typeof payload.playerId === 'number' &&
+            typeof payload.targetId === 'number') {
+          this.fireMissile(payload.playerId, payload.targetId);
+        }
+        break;
+      default:
+        // Unknown actions are ignored.
+        break;
+    }
+  }
+}
+
+const legacyMap = {
+  MOVE: 'move',
+  FIRE: 'fireMissile',
+};
+
+const wss = new WebSocket.Server({ port: 8080 });
+const game = new Game();
+
+function broadcast(data) {
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(data);
+    }
+  }
+}
+
+wss.on('connection', ws => {
+  ws.on('message', message => {
+    if (message.length > 1024) {
+      return; // drop overly large messages
+    }
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (err) {
+      return; // ignore invalid JSON
+    }
+    const mappedType = legacyMap[data.type] || data.type;
+    if (!mappedType) return;
+    game.handleAction({ type: mappedType, payload: data.payload });
+  });
+});
+
+game.on('entityChange', change => {
+  broadcast(JSON.stringify(change));
+});
+
+console.log('WebSocket bridge running on port 8080');


### PR DESCRIPTION
## Summary
- add a WebSocket server in `wsbridge/` that translates WebSocket messages into sample game actions
- emit JSON entity change messages to all WebSocket clients
- map legacy message names to new action types and validate inbound data
- document the bridge in the project README
- ignore `node_modules` folders

## Testing
- `node wsbridge/server.js`

------
https://chatgpt.com/codex/tasks/task_e_683ff53d43bc8321a443b5b6caba33f3