### PR TITLE
Add LaunchServerJS protocol module

### DIFF
--- a/LaunchServerJS/src/network/protocol.ts
+++ b/LaunchServerJS/src/network/protocol.ts
@@ -1,0 +1,38 @@
+export enum MessageType {
+  AUTHORISE = 'authorise',
+  LOCATION_UPDATE = 'locationUpdate',
+  KEEP_ALIVE = 'keepAlive'
+}
+
+export interface BaseMessage {
+  type: MessageType;
+}
+
+export interface AuthoriseMessage extends BaseMessage {
+  type: MessageType.AUTHORISE;
+  deviceId: string;
+  version: string;
+}
+
+export interface LocationUpdateMessage extends BaseMessage {
+  type: MessageType.LOCATION_UPDATE;
+  latitude: number;
+  longitude: number;
+}
+
+export interface KeepAliveMessage extends BaseMessage {
+  type: MessageType.KEEP_ALIVE;
+}
+
+export type LaunchMessage =
+  | AuthoriseMessage
+  | LocationUpdateMessage
+  | KeepAliveMessage;
+
+export function serializeMessage(message: LaunchMessage): string {
+  return JSON.stringify(message);
+}
+
+export function parseMessage(json: string): LaunchMessage {
+  return JSON.parse(json) as LaunchMessage;
+}

--- a/docs/network.md
+++ b/docs/network.md
@@ -1,0 +1,54 @@
+# Network Protocol
+
+LaunchServerJS communicates using JSON encoded messages. Each message includes a
+`type` field which replaces the numeric message identifiers used in the legacy
+Java implementation. The protocol currently defines the following messages:
+
+## BaseMessage
+```ts
+interface BaseMessage {
+  type: MessageType;
+}
+```
+
+## AuthoriseMessage
+```ts
+interface AuthoriseMessage extends BaseMessage {
+  type: MessageType.AUTHORISE;
+  deviceId: string;
+  version: string;
+}
+```
+Sent by a client when connecting to the server. The server verifies the device
+and game version before allowing further communication.
+
+## LocationUpdateMessage
+```ts
+interface LocationUpdateMessage extends BaseMessage {
+  type: MessageType.LOCATION_UPDATE;
+  latitude: number;
+  longitude: number;
+}
+```
+Periodic location update from the client.
+
+## KeepAliveMessage
+```ts
+interface KeepAliveMessage extends BaseMessage {
+  type: MessageType.KEEP_ALIVE;
+}
+```
+Used when no other data needs to be sent to maintain the connection.
+
+## Serialisation
+
+Messages are encoded and decoded with the helper functions provided in
+`src/network/protocol.ts`:
+
+```ts
+serializeMessage(message: LaunchMessage): string
+parseMessage(json: string): LaunchMessage
+```
+
+These convert between TypeScript objects and their JSON string representation.
+


### PR DESCRIPTION
## Summary
- define TypeScript interfaces for network messages in `protocol.ts`
- use string based message identifiers instead of numeric IDs
- add JSON serialization helpers
- document the protocol in `docs/network.md`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683ff2a792348321a324257391b4a0a7