### PR TITLE
Fix typo preventing server console from quitting

### DIFF
--- a/LaunchServer/src/launchserver/LaunchConsole.java
+++ b/LaunchServer/src/launchserver/LaunchConsole.java
@@ -1272,7 +1272,12 @@ public class LaunchConsole
         LaunchLog.ConsoleMessage("\n---------------------------");
     }
     
-    public boolean Quat()
+    /**
+     * Indicates whether the console has received a quit command.
+     *
+     * @return true if the console should quit.
+     */
+    public boolean Quit()
     {
         return bQuit;
     }

--- a/LaunchServer/src/launchserver/LaunchServer.java
+++ b/LaunchServer/src/launchserver/LaunchServer.java
@@ -116,7 +116,7 @@ public class LaunchServer implements LaunchServerAppInterface, GameLoadSaveListe
             
             LaunchConsole console = new LaunchConsole(this, game);
         
-            while(!console.Quat() && game.GetRunning())
+            while(!console.Quit() && game.GetRunning())
             {
                 console.Tick();
             }


### PR DESCRIPTION
## Summary
- correct `Quat` -> `Quit` typo so server shutdown loop works
- add JavaDoc for `Quit` method

## Testing
- `ant -f build.xml` *(fails: Source option 7 is no longer supported)*

------
https://chatgpt.com/codex/tasks/task_e_683fef6d9a9c8321ad4679b864ebb642