### PR TITLE
Fix LaunchServerJS/package.json merge conflict

### DIFF
--- a/LaunchServerJS/package.json
+++ b/LaunchServerJS/package.json
@@ -1,9 +1,5 @@
 {
   "name": "launchserverjs",
-  "module": "src/index.ts",
-  "type": "module",
-  "private": true,
-=======
   "module": "./src/server.ts",
   "type": "module",
   "private": true,
@@ -12,38 +8,19 @@
     "build": "bun build ./src/server.ts --outdir dist --target bun",
     "start": "bun run ./dist/server.js"
   },
-  "devDependencies": {
-    "@types/bun": "latest"
-  },
-  "peerDependencies": {
-    "typescript": "^5"
-  },
-  "dependencies": {
-    "openid-client": "^6.5.0"
-
-  "version": "1.0.0",
-  "type": "commonjs",
-  "scripts": {
-    "build": "tsc",
-    "start": "node dist/server.js"
-  },
-  "devDependencies": {
-    "typescript": "^5.8.3",
-    "@types/node": "^20.5.9"
-
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "start": "node src/index.js"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0",
     "js-yaml": "^4.1.0",
+    "openid-client": "^6.5.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^20.5.9",
+    "typescript": "^5.8.3"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- resolve merge conflicts in LaunchServerJS/package.json
- keep bun server entry `./src/server.ts`

## Testing
- `npm install --package-lock-only --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_684012fb64f083219cb3949fb303c63e