### PR TITLE
Update network docs and clean server

### DIFF
--- a/LaunchServerJS/README.md
+++ b/LaunchServerJS/README.md
@@ -1,27 +1,28 @@
-# launchserverjs
+# LaunchServerJS
 
-To install dependencies:
+A lightweight game server written with [Bun](https://bun.sh/).
+
+## Getting Started
+
+Install dependencies:
 
 ```bash
 bun install
 ```
 
-To run:
-
-```bash
-bun run index.ts
-=======
-To run the development server:
+Run the development server:
 
 ```bash
 bun run src/server.ts
 ```
 
-To build and run the bundled server:
+Build and run the bundled server:
 
 ```bash
 bun run build
 bun run start
 ```
 
-This project was created using `bun init` in bun v1.2.14. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+See [docs/network.md](docs/network.md) for message format details.
+
+This project was created using `bun init`.

--- a/LaunchServerJS/docs/network.md
+++ b/LaunchServerJS/docs/network.md
@@ -1,15 +1,14 @@
 # JSON Network Protocol
 
-All messages are JSON objects with a mandatory `type` field.
+LaunchServerJS exchanges JSON messages over WebSockets. Every message contains a `type` field which identifies its purpose.
 
-## Authorise
+## Message Types
 
-Client -> Server
-```json
-{ "type": "authorise", "deviceId": "abc", "version": "1.0" }
-```
+| Name | Direction | Example |
+|------|-----------|---------|
+| `authorise` | client -> server | `{ "type": "authorise", "deviceId": "abc", "version": "1.0.0" }` |
+| `authorised` | server -> client | `{ "type": "authorised" }` |
+| `locationUpdate` | client -> server | `{ "type": "locationUpdate", "latitude": 51.5, "longitude": -0.1 }` |
+| `keepAlive` | client -> server | `{ "type": "keepAlive" }` |
 
-Server -> Client
-```json
-{ "type": "authorised" }
-```
+See the root [docs/network.md](../../docs/network.md) for full TypeScript interfaces.

--- a/LaunchServerJS/src/network/protocol.ts
+++ b/LaunchServerJS/src/network/protocol.ts
@@ -1,7 +1,7 @@
 export enum MessageType {
   AUTHORISE = 'authorise',
   LOCATION_UPDATE = 'locationUpdate',
-  KEEP_ALIVE = 'keepAlive'
+  KEEP_ALIVE = 'keepAlive',
 }
 
 export interface BaseMessage {
@@ -10,13 +10,6 @@ export interface BaseMessage {
 
 export interface AuthoriseMessage extends BaseMessage {
   type: MessageType.AUTHORISE;
-=======
-export interface BaseMessage {
-  type: string;
-}
-
-export interface AuthoriseMessage extends BaseMessage {
-  type: "authorise";
   deviceId: string;
   version: string;
 }
@@ -42,16 +35,4 @@ export function serializeMessage(message: LaunchMessage): string {
 
 export function parseMessage(json: string): LaunchMessage {
   return JSON.parse(json) as LaunchMessage;
-=======
-export type ClientMessage = AuthoriseMessage | BaseMessage;
-
-export function handleMessage(ws: WebSocket, msg: ClientMessage) {
-  switch (msg.type) {
-    case "authorise":
-      // TODO authenticate deviceId/version
-      ws.send(JSON.stringify({ type: "authorised" }));
-      break;
-    default:
-      ws.send(JSON.stringify({ type: "error", message: "Unknown message" }));
-  }
 }

--- a/LaunchServerJS/src/server.ts
+++ b/LaunchServerJS/src/server.ts
@@ -1,4 +1,5 @@
 import { serve } from "bun";
+import { Logger } from "./utils/log";
 
 interface Session {
   id: number;
@@ -91,38 +92,7 @@ const server = serve({
   },
 });
 
-console.log(`LaunchServerJS listening on ${server.hostname}:${server.port}`);
-=======
-import { handleMessage, BaseMessage } from "./network/protocol";
-
-serve({
-  port: 3000,
-  fetch(req, server) {
-    if (server.upgrade(req)) {
-      return undefined;
-    }
-    return new Response("WebSocket server only", { status: 400 });
-  },
-  websocket: {
-    open(ws) {
-      ws.send(JSON.stringify({ type: "welcome" }));
-    },
-    message(ws, data) {
-      try {
-        const msg: BaseMessage = JSON.parse(data.toString());
-        handleMessage(ws, msg);
-      } catch (err) {
-        ws.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
-      }
-    },
-    close(ws) {
-      // TODO: cleanup sessions
-    },
-  },
-});
-
-console.log("Server running on ws://localhost:3000");
-import { Logger } from './utils/log';
+  console.log(`LaunchServerJS listening on ${server.hostname}:${server.port}`);
 
 process.on('uncaughtException', (err: unknown) => {
   Logger.error(`Unhandled exception: ${err instanceof Error ? err.stack : err}`);

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Aspirations are to randomize player locations each week and use mars instead of 
 |--------|----------|-----------------|------|
 | `LaunchServer` | Java (Ant) | `ant run` or open in NetBeans | [HOW TO DEPLOY](LaunchServer/HOW%20TO%20DEPLOY) |
 | `LaunchClient` | Android (Java/Kotlin) | `./gradlew assembleDebug` | – |
-| `LaunchServerJS` | TypeScript with Bun | `bun run src/server.ts` | [README](LaunchServerJS/README.md), [docs](LaunchServerJS/docs) |
+| `LaunchServerJS` | TypeScript with Bun | `bun run src/server.ts` | [README](LaunchServerJS/README.md), [network](docs/network.md) |
 | `wsbridge` | Node.js | `node server.js` | – |
 | `mcp` | Node.js Express | `node index.js` | [openapi.yaml](mcp/openapi.yaml) |
 | `server-ts` | TypeScript | `npm run build` | – |
@@ -56,6 +56,7 @@ Older versions of Launch relied on a custom binary protocol implemented in the
 offsets for each field. The new implementation uses JSON over WebSockets. This
 makes it much easier to inspect traffic and build tooling in other languages,
 while still keeping the payloads small thanks to Bun's native JSON handling.
+For a full list of message structures see [docs/network.md](docs/network.md).
 
 ## Running Tests
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -4,6 +4,16 @@ LaunchServerJS communicates using JSON encoded messages. Each message includes a
 `type` field which replaces the numeric message identifiers used in the legacy
 Java implementation. The protocol currently defines the following messages:
 
+## MessageType
+
+```ts
+enum MessageType {
+  AUTHORISE = 'authorise',
+  LOCATION_UPDATE = 'locationUpdate',
+  KEEP_ALIVE = 'keepAlive',
+}
+```
+
 ## BaseMessage
 ```ts
 interface BaseMessage {
@@ -22,6 +32,12 @@ interface AuthoriseMessage extends BaseMessage {
 Sent by a client when connecting to the server. The server verifies the device
 and game version before allowing further communication.
 
+Example:
+
+```json
+{ "type": "authorise", "deviceId": "abc", "version": "1.0.0" }
+```
+
 ## LocationUpdateMessage
 ```ts
 interface LocationUpdateMessage extends BaseMessage {
@@ -32,6 +48,12 @@ interface LocationUpdateMessage extends BaseMessage {
 ```
 Periodic location update from the client.
 
+Example:
+
+```json
+{ "type": "locationUpdate", "latitude": 51.5, "longitude": -0.1 }
+```
+
 ## KeepAliveMessage
 ```ts
 interface KeepAliveMessage extends BaseMessage {
@@ -39,6 +61,27 @@ interface KeepAliveMessage extends BaseMessage {
 }
 ```
 Used when no other data needs to be sent to maintain the connection.
+
+Example:
+
+```json
+{ "type": "keepAlive" }
+```
+
+## AuthorisedMessage
+
+```ts
+interface AuthorisedMessage extends BaseMessage {
+  type: 'authorised';
+}
+```
+Sent by the server in response to a successful `AuthoriseMessage`.
+
+Example:
+
+```json
+{ "type": "authorised" }
+```
 
 ## Serialisation
 


### PR DESCRIPTION
## Summary
- clean up leftover merge markers in the Bun server and protocol files
- expand protocol documentation with examples
- add quick reference to message types
- update READMEs with new documentation links

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68408158f6ac8321bf7ce9e18f8b17d3