### PR TITLE
Enable Bun tests on GitHub Actions

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -1,0 +1,20 @@
+name: Bun Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install
+      - name: Run tests
+        run: bun test

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Tests for the Bun services can be executed with:
 bun test
 ```
 
+These tests also run automatically on GitHub Actions for each push and pull request.
+
 Existing Java modules still contain JUnit tests under `LaunchGame/test` which
 can be run with your preferred Java IDE or with Ant/NetBeans.
 ## MCP Service


### PR DESCRIPTION
## Summary
- add CI workflow using oven-sh/setup-bun
- document that tests run automatically on GitHub Actions

## Testing
- `bun install`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68409cc3cfdc8321ba92587b698acad0